### PR TITLE
Adição de status ARQUIVADO em chamados.

### DIFF
--- a/src/main/java/org/soulcodeacademy/helpr/domain/enums/StatusChamado.java
+++ b/src/main/java/org/soulcodeacademy/helpr/domain/enums/StatusChamado.java
@@ -3,5 +3,6 @@ package org.soulcodeacademy.helpr.domain.enums;
 public enum StatusChamado {
     RECEBIDO, // Quando o chamado é criado
     ATRIBUIDO, // Quando um funcionário está resolvendo o chamado
-    CONCLUIDO // Quando o chamado foi resolvido
+    CONCLUIDO, // Quando o chamado foi resolvido
+    ARQUIVADO
 }

--- a/src/main/java/org/soulcodeacademy/helpr/services/ChamadoService.java
+++ b/src/main/java/org/soulcodeacademy/helpr/services/ChamadoService.java
@@ -47,9 +47,6 @@ public class ChamadoService {
     public Chamado atualizar(Integer idChamado, ChamadoDTO dto) {
         Chamado chamadoAtual = this.getChamado(idChamado);
         Cliente cliente = this.clienteService.getCliente(dto.getIdCliente());
-        chamadoAtual.setTitulo(dto.getTitulo());
-        chamadoAtual.setDescricao(dto.getDescricao());
-        chamadoAtual.setCliente(cliente);
 
         if (dto.getIdFuncionario() == null) {
             throw new ParametrosInsuficientesError("idFuncionario obrigatório");
@@ -61,16 +58,30 @@ public class ChamadoService {
                     chamadoAtual.setStatus(StatusChamado.RECEBIDO);
                     chamadoAtual.setFuncionario(null);
                     chamadoAtual.setDataFechamento(null);
+                    chamadoAtual.setTitulo(dto.getTitulo());
+                    chamadoAtual.setDescricao(dto.getDescricao());
+                    chamadoAtual.setCliente(cliente);
                 }
                 case ATRIBUIDO -> {
                     chamadoAtual.setStatus(StatusChamado.ATRIBUIDO);
                     chamadoAtual.setFuncionario(funcionario);
                     chamadoAtual.setDataFechamento(null);
+                    chamadoAtual.setTitulo(dto.getTitulo());
+                    chamadoAtual.setDescricao(dto.getDescricao());
+                    chamadoAtual.setCliente(cliente);
                 }
                 case CONCLUIDO -> {
                     chamadoAtual.setStatus(StatusChamado.CONCLUIDO);
                     chamadoAtual.setFuncionario(funcionario);
                     chamadoAtual.setDataFechamento(LocalDate.now());
+                    chamadoAtual.setTitulo(dto.getTitulo());
+                    chamadoAtual.setDescricao(dto.getDescricao());
+                    chamadoAtual.setCliente(cliente);
+                }
+                case ARQUIVADO -> {
+                    chamadoAtual.setStatus(StatusChamado.ARQUIVADO);
+                    chamadoAtual.setFuncionario(funcionario);
+                    chamadoAtual.setDataFechamento(null);
                 }
             }
         }

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,7 +1,6 @@
 spring.datasource.url=jdbc:mysql://localhost:3306/helpr?createDatabaseIfNotExist=true
 spring.datasource.username=root
-spring.datasource.password=mdpf@123
-spring.datasource.password=21309
+spring.datasource.password=12345678
 spring.jpa.generate-ddl=true
 spring.jpa.hibernate.ddl-auto=create
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5InnoDBDialect


### PR DESCRIPTION
[ ] Adicionar ao enum de StatusChamado a constante ARQUIVADO. Esse status indica que o chamado está num estado de "Apagado do sistema", porém ele não será apagado de verdade.

[ ] Em seguida, verifique como o método de atualizar chamado irá se comportar com a adição desta nova opção, faça as alterações necessárias (ao arquivar um chamado não altera os dados já presentes no chamado).