### PR TITLE
Refatoração da obrigatoriedade da senha

### DIFF
--- a/src/main/java/org/soulcodeacademy/helpr/domain/Usuario.java
+++ b/src/main/java/org/soulcodeacademy/helpr/domain/Usuario.java
@@ -22,7 +22,7 @@ public abstract class Usuario { // Não será possível criar objetos desta clas
     protected String cpf;
 
     @JsonIgnore // impede a leitura da senha no JSON
-    @Column(nullable = false)
+    @Column()
     protected String senha;
 
     // Representa os valores do ENUM como texto

--- a/src/main/java/org/soulcodeacademy/helpr/domain/dto/UsuarioDTO.java
+++ b/src/main/java/org/soulcodeacademy/helpr/domain/dto/UsuarioDTO.java
@@ -1,6 +1,7 @@
 package org.soulcodeacademy.helpr.domain.dto;
 
 import org.hibernate.validator.constraints.br.CPF;
+import org.soulcodeacademy.helpr.services.errors.RecursoNaoEncontradoError;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
@@ -19,7 +20,6 @@ public abstract class UsuarioDTO {
     @NotBlank(message = "CPF é obrigatório")
     protected String cpf;
 
-    @NotBlank(message = "Senha é obrigatória")
     protected String senha;
 
     public String getNome() {

--- a/src/main/java/org/soulcodeacademy/helpr/services/ClienteService.java
+++ b/src/main/java/org/soulcodeacademy/helpr/services/ClienteService.java
@@ -3,6 +3,7 @@ package org.soulcodeacademy.helpr.services;
 import org.soulcodeacademy.helpr.domain.Cliente;
 import org.soulcodeacademy.helpr.domain.dto.ClienteDTO;
 import org.soulcodeacademy.helpr.repositories.ClienteRepository;
+import org.soulcodeacademy.helpr.services.errors.ParametrosInsuficientesError;
 import org.soulcodeacademy.helpr.services.errors.RecursoNaoEncontradoError;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -26,6 +27,9 @@ public class ClienteService {
     }
 
     public Cliente salvar(ClienteDTO dto) {
+        if(dto.getSenha().isBlank()){
+            throw new ParametrosInsuficientesError("Senha é obrigatória!");
+        }
         // Criação da entidade Cliente, a partir dos dados validados do DTO
         Cliente novoCliente = new Cliente(null, dto.getNome(), dto.getEmail(), dto.getCpf(), dto.getSenha(), dto.getTelefone());
 

--- a/src/main/java/org/soulcodeacademy/helpr/services/FuncionarioService.java
+++ b/src/main/java/org/soulcodeacademy/helpr/services/FuncionarioService.java
@@ -4,6 +4,7 @@ import org.soulcodeacademy.helpr.domain.Cargo;
 import org.soulcodeacademy.helpr.domain.Funcionario;
 import org.soulcodeacademy.helpr.domain.dto.FuncionarioDTO;
 import org.soulcodeacademy.helpr.repositories.FuncionarioRepository;
+import org.soulcodeacademy.helpr.services.errors.ParametrosInsuficientesError;
 import org.soulcodeacademy.helpr.services.errors.RecursoNaoEncontradoError;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -34,6 +35,9 @@ public class FuncionarioService {
     }
 
     public Funcionario salvar(FuncionarioDTO dto) {
+        if(dto.getSenha().isBlank()){
+            throw new ParametrosInsuficientesError("Senha é obrigatória!");
+        }
         Cargo cargo = this.cargoService.getCargo(dto.getIdCargo()); // verifica se o cargo existe mesmo
         // id, nome, email,cpf, String senha, foto, cargo
         // Transferindo informações do DTO para nossa entidade


### PR DESCRIPTION
Sempre ao atualizarmos os usuários, somos obrigados a passar uma senha nova, no entanto, isto é impraticável para uma aplicação em larga escala.

Desabilite o @notblank do UsuarioDTO, porém ao salvar um novo usuário é imprescindível verificar a nulidade da senha.

closes #33 